### PR TITLE
feat: add completed tasks command

### DIFF
--- a/bin/ticktick.js
+++ b/bin/ticktick.js
@@ -234,6 +234,14 @@ async function handleTasks() {
       return await tasks.due(parseInt(args.positional[0]) || 7);
     case 'priority':
       return await tasks.priority();
+    case 'completed': {
+      const projectIds = args.options.projects ? args.options.projects.split(',').map((p) => p.trim()) : undefined;
+      return await tasks.listCompleted({
+        projectIds,
+        startDate: args.options.from,
+        endDate: args.options.to,
+      });
+    }
     default:
       console.error(`Unknown tasks subcommand: ${args.subcommand}`);
       console.log(getTasksHelp());

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -366,6 +366,7 @@ Subcommands:
   search <keyword>                 Search all tasks
   due [days]                       Tasks due within N days (default: 7)
   priority                         High priority tasks
+  completed                        List completed tasks in a date range
 
 Create/Update options:
   --project <id>         Project ID (for create, optional)
@@ -380,6 +381,11 @@ Search options:
   --tags <tags>          Filter by tags (comma-separated)
   --priority <level>     Filter by priority
 
+Completed options:
+  --from <date>          Start of date range (ISO 8601)
+  --to <date>            End of date range (ISO 8601)
+  --projects <ids>       Comma-separated project IDs to filter
+
 Examples:
   ticktick tasks create "Buy groceries" --due 2026-01-30 --priority high
   ticktick tasks create "Call mom" --tags "personal,family"
@@ -388,5 +394,7 @@ Examples:
   ticktick tasks complete PROJECT_ID TASK_ID
   ticktick tasks search "meeting"
   ticktick tasks search --tags "work"
-  ticktick tasks due 3`;
+  ticktick tasks due 3
+  ticktick tasks completed --from 2026-03-06T00:00:00.000+0000 --to 2026-03-06T23:59:59.000+0000
+  ticktick tasks completed --projects PROJECT_ID1,PROJECT_ID2`;
 }

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -227,5 +227,21 @@ export function createServer(deps = {}) {
     }
   );
 
+  server.tool(
+    'ticktick_tasks_completed',
+    'List completed TickTick tasks within a date range',
+    {
+      projectIds: z.array(z.string()).optional().describe('Project IDs to filter (omit for all projects)'),
+      startDate: z.string().optional().describe('Start of date range, ISO 8601 (e.g. 2026-03-06T00:00:00.000+0000)'),
+      endDate: z.string().optional().describe('End of date range, ISO 8601 (e.g. 2026-03-06T23:59:59.000+0000)'),
+    },
+    async ({ projectIds, startDate, endDate }) => {
+      const result = await tasksModule.listCompleted({ projectIds, startDate, endDate }, moduleDeps);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
   return server;
 }

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -319,6 +319,48 @@ export async function due(days = 7, deps = {}) {
 }
 
 /**
+ * List completed tasks within a date range across specified projects (or all projects)
+ * @param {object} options - Filter options
+ * @param {string[]} [options.projectIds] - Project IDs to filter (omit for all projects)
+ * @param {string} [options.startDate] - ISO 8601 start date (inclusive, filters by completedTime)
+ * @param {string} [options.endDate] - ISO 8601 end date (inclusive, filters by completedTime)
+ * @returns {Promise<object>}
+ */
+export async function listCompleted(options = {}, deps = {}) {
+  const {
+    apiRequest = coreFunctions.apiRequest,
+    formatPriority = coreFunctions.formatPriority,
+    shortId = coreFunctions.shortId,
+  } = deps;
+
+  const body = {};
+  if (options.projectIds?.length) body.projectIds = options.projectIds;
+  if (options.startDate) body.startDate = options.startDate;
+  if (options.endDate) body.endDate = options.endDate;
+
+  const tasks = await apiRequest('POST', '/task/completed', body, deps);
+  const results = tasks.map((t) => ({
+    id: shortId(t.id),
+    fullId: t.id,
+    projectId: shortId(t.projectId),
+    fullProjectId: t.projectId,
+    title: t.title,
+    content: t.content || '',
+    completedTime: t.completedTime,
+    dueDate: t.dueDate,
+    priority: formatPriority(t.priority),
+    tags: t.tags || [],
+  }));
+
+  results.sort((a, b) => new Date(b.completedTime) - new Date(a.completedTime));
+
+  return {
+    count: results.length,
+    tasks: results,
+  };
+}
+
+/**
  * Get high priority tasks
  * @returns {Promise<object>}
  */


### PR DESCRIPTION
## Summary

Adds support for listing completed tasks using the TickTick Open API `POST /open/v1/task/completed` endpoint.

## Changes

- **`lib/tasks.js`**: Add `listCompleted()` function — calls `POST /task/completed` with optional `projectIds`, `startDate`, `endDate` filters. Results sorted by `completedTime` descending.
- **`lib/mcp.js`**: Add `ticktick_tasks_completed` MCP tool exposing the same filters.
- **`bin/ticktick.js`**: Add `completed` subcommand with `--from`, `--to`, `--projects` flags.
- **`lib/cli.js`**: Update help text with new subcommand and options.

## Usage

CLI:
```bash
ticktick tasks completed --from 2026-03-06T00:00:00.000+0000 --to 2026-03-06T23:59:59.000+0000
ticktick tasks completed --projects PROJECT_ID1,PROJECT_ID2
```

MCP tool: `ticktick_tasks_completed` with optional `projectIds`, `startDate`, `endDate` params.