### PR TITLE
feat: add folder filtering by groupId

### DIFF
--- a/bin/ticktick.js
+++ b/bin/ticktick.js
@@ -231,13 +231,14 @@ async function handleTasks() {
       });
     }
     case 'due':
-      return await tasks.due(parseInt(args.positional[0]) || 7);
+      return await tasks.due(parseInt(args.positional[0]) || 7, { folder: args.options.folder });
     case 'priority':
       return await tasks.priority();
     case 'completed': {
       const projectIds = args.options.projects ? args.options.projects.split(',').map((p) => p.trim()) : undefined;
       return await tasks.listCompleted({
         projectIds,
+        folder: args.options.folder,
         startDate: args.options.from,
         endDate: args.options.to,
       });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -381,6 +381,9 @@ Search options:
   --tags <tags>          Filter by tags (comma-separated)
   --priority <level>     Filter by priority
 
+Completed/Due options:
+  --folder <groupId>     Filter by project folder (groupId)
+
 Completed options:
   --from <date>          Start of date range (ISO 8601)
   --to <date>            End of date range (ISO 8601)

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -206,9 +206,10 @@ export function createServer(deps = {}) {
     'Get TickTick tasks due within N days',
     {
       days: z.number().optional().default(7).describe('Number of days to look ahead (default: 7)'),
+      folder: z.string().optional().describe('Filter by project folder (groupId)'),
     },
-    async ({ days }) => {
-      const result = await tasksModule.due(days, moduleDeps);
+    async ({ days, folder }) => {
+      const result = await tasksModule.due(days, { folder }, moduleDeps);
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };
@@ -232,11 +233,12 @@ export function createServer(deps = {}) {
     'List completed TickTick tasks within a date range',
     {
       projectIds: z.array(z.string()).optional().describe('Project IDs to filter (omit for all projects)'),
+      folder: z.string().optional().describe('Filter by project folder (groupId)'),
       startDate: z.string().optional().describe('Start of date range, ISO 8601 (e.g. 2026-03-06T00:00:00.000+0000)'),
       endDate: z.string().optional().describe('End of date range, ISO 8601 (e.g. 2026-03-06T23:59:59.000+0000)'),
     },
-    async ({ projectIds, startDate, endDate }) => {
-      const result = await tasksModule.listCompleted({ projectIds, startDate, endDate }, moduleDeps);
+    async ({ projectIds, folder, startDate, endDate }) => {
+      const result = await tasksModule.listCompleted({ projectIds, folder, startDate, endDate }, moduleDeps);
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -19,6 +19,7 @@ export async function list(deps = {}) {
     viewMode: p.viewMode,
     kind: p.kind,
     closed: p.closed,
+    groupId: p.groupId,
   }));
 }
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -269,15 +269,20 @@ export async function search(keyword, options = {}, deps = {}) {
 /**
  * Get tasks due within N days (includes overdue tasks)
  * @param {number} days - Number of days (default: 7)
+ * @param {object} options - Filter options
+ * @param {string} [options.folder] - Filter by project groupId
  * @returns {Promise<object>}
  */
-export async function due(days = 7, deps = {}) {
+export async function due(days = 7, options = {}, deps = {}) {
   const {
     apiRequest = coreFunctions.apiRequest,
     formatPriority = coreFunctions.formatPriority,
     shortId = coreFunctions.shortId,
   } = deps;
-  const projects = await apiRequest('GET', '/project', undefined, deps);
+  const allProjects = await apiRequest('GET', '/project', undefined, deps);
+  const projects = options.folder
+    ? allProjects.filter((p) => p.groupId === options.folder)
+    : allProjects;
   const results = [];
   const now = new Date();
   const cutoff = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
@@ -322,6 +327,7 @@ export async function due(days = 7, deps = {}) {
  * List completed tasks within a date range across specified projects (or all projects)
  * @param {object} options - Filter options
  * @param {string[]} [options.projectIds] - Project IDs to filter (omit for all projects)
+ * @param {string} [options.folder] - Filter by project groupId (resolved to projectIds)
  * @param {string} [options.startDate] - ISO 8601 start date (inclusive, filters by completedTime)
  * @param {string} [options.endDate] - ISO 8601 end date (inclusive, filters by completedTime)
  * @returns {Promise<object>}
@@ -333,8 +339,16 @@ export async function listCompleted(options = {}, deps = {}) {
     shortId = coreFunctions.shortId,
   } = deps;
 
+  let projectIds = options.projectIds;
+  if (options.folder && !projectIds?.length) {
+    const allProjects = await apiRequest('GET', '/project', undefined, deps);
+    projectIds = allProjects
+      .filter((p) => p.groupId === options.folder)
+      .map((p) => p.id);
+  }
+
   const body = {};
-  if (options.projectIds?.length) body.projectIds = options.projectIds;
+  if (projectIds?.length) body.projectIds = projectIds;
   if (options.startDate) body.startDate = options.startDate;
   if (options.endDate) body.endDate = options.endDate;
 


### PR DESCRIPTION
## Summary

Adds `--folder <groupId>` filtering to `due` and `completed` commands, allowing tasks to be scoped to a specific TickTick project folder.

## Changes

- **`lib/projects.js`**: Include `groupId` in projects list output
- **`lib/tasks.js`**: Add `folder` option to `due()` and `listCompleted()` — filters projects by `groupId` before querying
- **`lib/mcp.js`**: Add `folder` param to `ticktick_tasks_due` and `ticktick_tasks_completed` MCP tools
- **`bin/ticktick.js`**: Wire `--folder` flag to `due` and `completed` subcommands
- **`lib/cli.js`**: Update help text

## Usage

```bash
# Get due tasks in a specific folder
ticktick tasks due --folder 6081d7f28ced111dfbae6fcd

# Get completed tasks today in a specific folder
ticktick tasks completed --folder 6081d7f28ced111dfbae6fcd --from 2026-03-06T08:00:00.000+0000 --to 2026-03-07T07:59:59.000+0000
```